### PR TITLE
More deterministic gates to ensure CLAUDE.md rules are really followed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Several conventions below are not just guidance — they are **mechanically enfo
 - `better-sqlite3` may only be imported inside `src/utils/database/` (the DB driver stays encapsulated behind the connection pool / cache layer).
 - `src/utils/` is a leaf layer — it must not import from `components/` or `pages/`.
 - Every Italian page under `src/pages/it/` delegates to a `Base*` shell from `src/components/pages/`.
-- `src/middleware.ts` guards the `/admin` route prefix.
+- `src/middleware.ts` guards the `/admin` route prefix — a structural canary in `architecture.test.ts` plus behavioural auth tests in [`src/middleware.test.ts`](src/middleware.test.ts) (401 without/with-wrong credentials, fails closed when unconfigured).
 
 When you change one of these intentionally, update the test first — it's the gate.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,18 +19,30 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Runtime entry point**: `node --import=./observability/otel/node-register.mjs ./dist/server/entry.mjs` — OpenTelemetry is auto-instrumented at startup.
 
+### Enforced architecture rules
+
+Several conventions below are not just guidance — they are **mechanically enforced** by architectural fitness functions in [`src/architecture.test.ts`](src/architecture.test.ts), which fail the build (and CI) on violation. That test is the source of truth for the exact rule; the prose here explains the intent. Currently enforced:
+
+- Components must not import from `pages/` (pages depend on components, not the reverse).
+- `better-sqlite3` may only be imported inside `src/utils/database/` (the DB driver stays encapsulated behind the connection pool / cache layer).
+- `src/utils/` is a leaf layer — it must not import from `components/` or `pages/`.
+- Every Italian page under `src/pages/it/` delegates to a `Base*` shell from `src/components/pages/`.
+- `src/middleware.ts` guards the `/admin` route prefix.
+
+When you change one of these intentionally, update the test first — it's the gate.
+
 ### i18n Routing
 Configured with `prefixDefaultLocale: false` and `strategy: prefix-other-locales`:
 - English (default): `/blog`, `/posts/my-post`, `/about`
 - Italian: `/it/blog`, `/it/posts/my-post`, `/it/about`
 
-Content collection IDs follow `{lang}/slug` format (e.g. `en/my-post`, `it/my-post`). When building `getStaticPaths()` for blog posts, the ID must be split to extract language and slug separately for correct URL generation. Italian pages live under `src/pages/it/` and delegate to `Base*` components from `src/components/pages/`.
+Content collection IDs follow `{lang}/slug` format (e.g. `en/my-post`, `it/my-post`). When building `getStaticPaths()` for blog posts, the ID must be split to extract language and slug separately for correct URL generation. Italian pages live under `src/pages/it/` and delegate to `Base*` components from `src/components/pages/` (enforced — see *Enforced architecture rules*).
 
 ### Content Collections
 Blog posts in `src/content/blog/{en|it}/` and presentations in `src/content/presentations/`. Schema defined with Zod in `src/content.config.ts`. Presentations are linked to blog posts via `blogPostSlug` and rendered with reveal.js at `/posts/[slug]/present`.
 
 ### Database
-SQLite via `better-sqlite3` with a connection pool in `src/utils/database/connection.ts`. Used for:
+SQLite via `better-sqlite3` with a connection pool in `src/utils/database/connection.ts` (driver import is confined to `src/utils/database/` — enforced). Used for:
 - **Caching**: API responses (Twitter feed, GitHub commits) with configurable TTL — 36 hours for Twitter
 - **Analytics**: Custom hit tracking with IP geolocation via `geolite2-redist`
 
@@ -40,7 +52,7 @@ In tests, the DB is replaced with an in-memory instance via `vitest.setup.ts`.
 Vitest with MSW (Mock Service Worker) for HTTP interception. `vitest.setup.ts` starts the MSW server and configures an in-memory SQLite DB before tests run. Handlers reset between tests. Test files live next to the code they test with a `.test.ts` suffix.
 
 ### Admin Routes
-`src/middleware.ts` protects `/admin/*` with HTTP Basic Auth using timing-safe comparison. Credentials come from `ADMIN_USER` / `ADMIN_PASS` env vars.
+`src/middleware.ts` protects `/admin/*` with HTTP Basic Auth using timing-safe comparison (the `/admin` guard is enforced). Credentials come from `ADMIN_USER` / `ADMIN_PASS` env vars.
 
 ## Code Style
 - **TypeScript**: Strict mode (extends `astro/tsconfigs/strict`)

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Architectural fitness functions.
+ *
+ * These tests turn the implicit conventions documented in CLAUDE.md into
+ * mechanically-enforced gates: rules a human (or an agent) simply cannot
+ * violate without the build going red. Each rule is verified to hold on the
+ * current codebase; if a future change breaks the intended architecture, the
+ * corresponding test fails and names the offending file.
+ */
+
+const SRC = import.meta.dirname;
+
+/** All source files under `dir` (relative to src/) with one of the given extensions. */
+function sourceFiles(dir: string, exts = ['.ts', '.astro']): string[] {
+  const root = path.join(SRC, dir);
+  let entries: string[];
+  try {
+    entries = readdirSync(root, { recursive: true }) as string[];
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => exts.includes(path.extname(e)))
+    .filter((e) => !e.endsWith('.test.ts') && !e.endsWith('.d.ts'))
+    .map((e) => path.join(root, e));
+}
+
+/** Raw module specifiers imported/exported-from/dynamically-imported by a file. */
+function importSpecifiers(file: string): string[] {
+  const content = readFileSync(file, 'utf8');
+  const specifiers: string[] = [];
+  const patterns = [
+    /\bimport\s+[^'"]*?\bfrom\s+['"]([^'"]+)['"]/g, // import x from '...'
+    /\bexport\s+[^'"]*?\bfrom\s+['"]([^'"]+)['"]/g, // export x from '...'
+    /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g, // import('...')
+    /\bimport\s+['"]([^'"]+)['"]/g, // import '...'
+  ];
+  for (const re of patterns) {
+    for (const m of content.matchAll(re)) specifiers.push(m[1]);
+  }
+  return specifiers;
+}
+
+/** Absolute path a relative import resolves to (null for bare/package imports). */
+function resolveLocal(fromFile: string, spec: string): string | null {
+  if (!spec.startsWith('.')) return null;
+  return path.resolve(path.dirname(fromFile), spec);
+}
+
+const PAGES = path.join(SRC, 'pages');
+const COMPONENTS = path.join(SRC, 'components');
+const COMPONENT_PAGES = path.join(COMPONENTS, 'pages');
+const DATABASE = path.join(SRC, 'utils', 'database');
+
+const isUnder = (target: string, dir: string) => target === dir || target.startsWith(dir + path.sep);
+
+describe('architectural fitness functions', () => {
+  it('R1: components must not import from pages (pages depend on components, not vice versa)', () => {
+    const violations: string[] = [];
+    for (const file of sourceFiles('components')) {
+      for (const spec of importSpecifiers(file)) {
+        const resolved = resolveLocal(file, spec);
+        if (resolved && isUnder(resolved, PAGES)) {
+          violations.push(`${path.relative(SRC, file)} imports '${spec}'`);
+        }
+      }
+    }
+    expect(violations, `Components must not depend on pages:\n${violations.join('\n')}`).toEqual([]);
+  });
+
+  it('R2: better-sqlite3 may only be imported inside src/utils/database', () => {
+    const violations: string[] = [];
+    for (const file of sourceFiles('.')) {
+      if (isUnder(file, DATABASE)) continue;
+      if (importSpecifiers(file).includes('better-sqlite3')) {
+        violations.push(path.relative(SRC, file));
+      }
+    }
+    expect(
+      violations,
+      `Raw DB driver must stay encapsulated in src/utils/database:\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('R3: every Italian page delegates to a components/pages/Base* shell', () => {
+    const violations: string[] = [];
+    for (const file of sourceFiles('pages/it', ['.astro'])) {
+      const delegates = importSpecifiers(file).some((s) => /components\/pages\/Base/.test(s));
+      if (!delegates) violations.push(path.relative(SRC, file));
+    }
+    expect(
+      violations,
+      `Italian pages must reuse a Base* page shell (no duplicated markup):\n${violations.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('R4: utils must not import from components or pages (utils is a leaf layer)', () => {
+    const violations: string[] = [];
+    for (const file of sourceFiles('utils')) {
+      for (const spec of importSpecifiers(file)) {
+        const resolved = resolveLocal(file, spec);
+        if (resolved && (isUnder(resolved, COMPONENTS) || isUnder(resolved, PAGES))) {
+          violations.push(`${path.relative(SRC, file)} imports '${spec}'`);
+        }
+      }
+    }
+    expect(violations, `Utils must not depend on UI layers:\n${violations.join('\n')}`).toEqual([]);
+  });
+
+  it('R5: middleware still guards the /admin route prefix', () => {
+    const middleware = readFileSync(path.join(SRC, 'middleware.ts'), 'utf8');
+    expect(middleware, 'middleware.ts must protect /admin routes').toMatch(/['"`]\/admin/);
+  });
+
+  // Guard against the rules silently testing nothing if a directory moves.
+  it('sanity: the rule scanners actually see source files', () => {
+    expect(sourceFiles('components').length).toBeGreaterThan(0);
+    expect(sourceFiles('utils').length).toBeGreaterThan(0);
+    expect(sourceFiles('pages/it', ['.astro']).length).toBeGreaterThan(0);
+    expect(COMPONENT_PAGES).toContain('components');
+  });
+});

--- a/src/architecture.test.ts
+++ b/src/architecture.test.ts
@@ -29,7 +29,13 @@ function sourceFiles(dir: string, exts = ['.ts', '.astro']): string[] {
     .map((e) => path.join(root, e));
 }
 
-/** Raw module specifiers imported/exported-from/dynamically-imported by a file. */
+/**
+ * Raw module specifiers imported/exported-from/dynamically-imported by a file.
+ * Regex-based (good enough for this ESM/Astro codebase): it handles multi-line,
+ * `import type`, re-exports, dynamic and side-effect imports. Known blind spot:
+ * a quote inside an inline comment within a multi-line import statement — not a
+ * pattern that occurs here. Switch to a TS AST parser if that ever bites.
+ */
 function importSpecifiers(file: string): string[] {
   const content = readFileSync(file, 'utf8');
   const specifiers: string[] = [];
@@ -111,9 +117,12 @@ describe('architectural fitness functions', () => {
     expect(violations, `Utils must not depend on UI layers:\n${violations.join('\n')}`).toEqual([]);
   });
 
-  it('R5: middleware still guards the /admin route prefix', () => {
+  it('R5: middleware still references the /admin prefix (structural canary)', () => {
+    // Cheap canary that the admin guard has not been deleted wholesale. The
+    // REAL authorization gate — that /admin actually denies/permits requests —
+    // lives in middleware.test.ts as a behavioural test.
     const middleware = readFileSync(path.join(SRC, 'middleware.ts'), 'utf8');
-    expect(middleware, 'middleware.ts must protect /admin routes').toMatch(/['"`]\/admin/);
+    expect(middleware, 'middleware.ts must reference /admin routes').toMatch(/['"`]\/admin/);
   });
 
   // Guard against the rules silently testing nothing if a directory moves.

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// astro:middleware is a virtual module; defineMiddleware just returns its handler.
+vi.mock('astro:middleware', () => ({ defineMiddleware: (fn: unknown) => fn }));
+
+/**
+ * Behavioural gate for the /admin Basic-Auth guard.
+ *
+ * The architectural fitness function (R5 in architecture.test.ts) only checks
+ * that middleware.ts still references the /admin prefix — a cheap structural
+ * canary. THIS file is the real authorization gate: it drives the middleware
+ * and asserts it actually denies/permits requests.
+ */
+
+const ORIGINAL_ENV = { ...process.env };
+const VALID_USER = 'admin';
+const VALID_PASS = 's3cr3t';
+
+// Credentials are read at module load, so import the middleware fresh after
+// setting the desired env for each scenario.
+async function loadMiddleware(env: { user?: string; pass?: string }) {
+  vi.resetModules();
+  if (env.user === undefined) delete process.env.ADMIN_USER;
+  else process.env.ADMIN_USER = env.user;
+  if (env.pass === undefined) delete process.env.ADMIN_PASS;
+  else process.env.ADMIN_PASS = env.pass;
+  const mod = await import('./middleware');
+  // The handler's real type expects a full Astro APIContext; for a focused unit
+  // test we drive it with the minimal { request, url } it actually reads.
+  return mod.onRequest as (context: unknown, next: unknown) => Promise<Response>;
+}
+
+function basicAuth(user: string, pass: string): string {
+  return 'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64');
+}
+
+function contextFor(pathname: string, authHeader?: string) {
+  const url = new URL(`http://localhost${pathname}`);
+  const headers = new Headers();
+  if (authHeader) headers.set('Authorization', authHeader);
+  return { request: new Request(url, { headers }), url };
+}
+
+const okNext = () => vi.fn(async () => new Response('ok', { status: 200 }));
+
+beforeEach(() => {
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+});
+
+describe('admin auth middleware', () => {
+  it('returns 401 and does not run the handler for /admin without credentials', async () => {
+    const onRequest = await loadMiddleware({ user: VALID_USER, pass: VALID_PASS });
+    const next = okNext();
+
+    const res = await onRequest(contextFor('/admin'), next);
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get('WWW-Authenticate')).toContain('Basic');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for /admin with wrong credentials', async () => {
+    const onRequest = await loadMiddleware({ user: VALID_USER, pass: VALID_PASS });
+    const next = okNext();
+
+    const res = await onRequest(contextFor('/admin/analytics', basicAuth(VALID_USER, 'wrong')), next);
+
+    expect(res.status).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows /admin through with correct credentials', async () => {
+    const onRequest = await loadMiddleware({ user: VALID_USER, pass: VALID_PASS });
+    const next = okNext();
+
+    const res = await onRequest(contextFor('/admin/analytics', basicAuth(VALID_USER, VALID_PASS)), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+  });
+
+  it('fails closed: denies /admin when ADMIN_USER/PASS are not configured', async () => {
+    const onRequest = await loadMiddleware({ user: undefined, pass: undefined });
+    const next = okNext();
+
+    const res = await onRequest(contextFor('/admin', basicAuth(VALID_USER, VALID_PASS)), next);
+
+    expect(res.status).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('does not require auth for non-admin routes', async () => {
+    const onRequest = await loadMiddleware({ user: VALID_USER, pass: VALID_PASS });
+    const next = okNext();
+
+    const res = await onRequest(contextFor('/blog'), next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    // Global discovery Link headers are appended on the way out.
+    expect(res.headers.get('Link')).toContain('llms.txt');
+  });
+});


### PR DESCRIPTION
Phase 3 of the deterministic-gates journey: turn the implicit conventions in CLAUDE.md into mechanically-enforced gates that a human or agent cannot violate without the build going red.

Rules (each verified to hold on the current codebase, and each proven to fail and name the offending file when violated):
- R1: components must not import from pages (layering direction).
- R2: better-sqlite3 may only be imported inside src/utils/database.
- R3: every Italian page delegates to a components/pages/Base* shell.
- R4: utils is a leaf layer (no imports from components/pages).
- R5: middleware still guards the /admin route prefix. Plus a sanity test so the scanners can't silently pass on zero files.

These run inside the existing vitest gate — no new CI wiring — so they block every PR via the checks job.