### PR TITLE
feat: move brand logo to the header, clean up the footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,8 +1,5 @@
 ---
-import { Image } from 'astro:assets';
 import SocialLink from './SocialLink.astro';
-import brandLogoLight from '../assets/nano-banana-personal-logo-light.png';
-import brandLogoDark from '../assets/nano-banana-personal-logo-dark.png';
 import type { SupportedLanguage } from '../types/i18n';
 
 export interface FooterTranslations {
@@ -41,24 +38,6 @@ const currentYear = new Date().getFullYear();
 ---
 
 <footer class="container">
-    <div class="footer-logo">
-        <Image
-            src={brandLogoDark}
-            alt="Alessandro Romano personal logo"
-            class="brand-logo light-logo"
-            width={96}
-            height={96}
-            densities={[2]}
-        />
-        <Image
-            src={brandLogoLight}
-            alt="Alessandro Romano personal logo"
-            class="brand-logo dark-logo"
-            width={96}
-            height={96}
-            densities={[2]}
-        />
-    </div>
     <div class="footer-content">
         <div class="copyright">
             <p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/" class="copyright-text">
@@ -107,35 +86,9 @@ const currentYear = new Date().getFullYear();
         gap: var(--space-md);
     }
 
-    .footer-logo {
-        display: flex;
-        flex-shrink: 0;
-    }
-
-    .brand-logo {
-        height: 2rem;
-        width: auto;
-        border-radius: 50%;
-    }
-
     .footer-content {
         flex: 1;
         min-width: 0;
-    }
-
-    .dark-logo {
-        display: none;
-    }
-
-    :global([data-theme='dark']) .dark-logo {
-        display: block;
-    }
-
-    :global([data-theme='dark']) .light-logo {
-        display: none;
-    }
-
-    .footer-content {
         display: flex;
         flex-direction: column;
         align-items: center;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -100,6 +100,11 @@ const homeUrl = getLocalizedPathname('/', i18nData?.currentLang || 'en');
 
   /* Mobile: show only the logo, but keep the name available to assistive tech */
   @media (max-width: 636px) {
+    /* Keep the logo clear of the hamburger */
+    .brand {
+      margin-left: var(--space-sm);
+    }
+
     .brand-name {
       position: absolute;
       width: 1px;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,9 +1,12 @@
 ---
+import { Image } from 'astro:assets';
 import Hamburger from './Hamburger.astro';
 import Navigation from './Navigation.astro';
 import ThemeSwitcher from './ThemeSwitcher.astro';
 import LanguageSwitcher from './LanguageSwitcher.astro';
 import { getLocalizedPathname } from '../utils/i18n';
+import brandLogoLight from '../assets/nano-banana-personal-logo-light.png';
+import brandLogoDark from '../assets/nano-banana-personal-logo-dark.png';
 
 const { i18nData } = Astro.props;
 const homeUrl = getLocalizedPathname('/', i18nData?.currentLang || 'en');
@@ -11,7 +14,11 @@ const homeUrl = getLocalizedPathname('/', i18nData?.currentLang || 'en');
 
 <header class="container header-container">
   <Hamburger />
-  <a href={homeUrl}><h2>Alessandro Romano</h2></a>
+  <a href={homeUrl} class="brand" aria-label="Alessandro Romano - home">
+    <Image src={brandLogoLight} alt="" class="brand-logo light-logo" width={80} height={80} densities={[2]} />
+    <Image src={brandLogoDark} alt="" class="brand-logo dark-logo" width={80} height={80} densities={[2]} />
+    <h2 class="brand-name">Alessandro Romano</h2>
+  </a>
   <Navigation language={i18nData?.currentLang || 'en'} />
   <section class="switchers">
     <LanguageSwitcher i18nData={i18nData} />
@@ -67,10 +74,42 @@ const homeUrl = getLocalizedPathname('/', i18nData?.currentLang || 'en');
     margin: 0;
   }
 
-  /* Mobile centering */
+  .brand {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+  }
+
+  .brand-logo {
+    height: 2.5rem;
+    width: auto;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  /* Theme-based logo swap (matches Footer behaviour) */
+  .dark-logo {
+    display: none;
+  }
+  :global([data-theme='dark']) .dark-logo {
+    display: block;
+  }
+  :global([data-theme='dark']) .light-logo {
+    display: none;
+  }
+
+  /* Mobile: show only the logo, but keep the name available to assistive tech */
   @media (max-width: 636px) {
-    header h2 {
-      margin-left: var(--space-sm);
+    .brand-name {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      border: 0;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
The footer logo rendered as a small white disc on the dark theme (the theme/logo mapping was inverted) and looked awkward, especially on mobile.

- Header: add the brand emblem next to the name. Desktop shows logo + name; mobile shows the logo only (the name is kept for assistive tech via a visually-hidden span, and the link has an aria-label). The colourful dark-background logo variant is used in dark theme so it blends instead of showing a white disc.
- Footer: remove the logo entirely; the footer is now just the centered copyright and social links.