### PR TITLE
test: property-based tests + fault injection (residuality)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "autocannon": "^8.0.0",
         "eslint": "^8.57.0",
         "eslint-plugin-astro": "^0.31.4",
+        "fast-check": "^4.8.0",
         "msw": "^2.11.5",
         "vitest": "^4.1.0"
       }
@@ -10280,6 +10281,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -14185,6 +14209,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "autocannon": "^8.0.0",
     "eslint": "^8.57.0",
     "eslint-plugin-astro": "^0.31.4",
+    "fast-check": "^4.8.0",
     "msw": "^2.11.5",
     "vitest": "^4.1.0"
   }

--- a/src/pages/api/contact.property.test.ts
+++ b/src/pages/api/contact.property.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fc from 'fast-check';
+
+// Same nodemailer mock as contact.test.ts so no real mail is sent.
+const { mockSendMail, mockCreateTransport, mockCreateTestAccount, mockGetTestMessageUrl } = vi.hoisted(() => {
+  const sendMail = vi.fn();
+  return {
+    mockSendMail: sendMail,
+    mockCreateTransport: vi.fn(() => ({ sendMail })),
+    mockCreateTestAccount: vi.fn(),
+    mockGetTestMessageUrl: vi.fn(),
+  };
+});
+
+vi.mock('nodemailer', () => ({
+  default: {
+    createTransport: mockCreateTransport,
+    createTestAccount: mockCreateTestAccount,
+    getTestMessageUrl: mockGetTestMessageUrl,
+  },
+}));
+
+import { POST } from './contact';
+
+const ORIGINAL_ENV = { ...process.env };
+const ALLOWED_STATUSES = new Set([200, 400, 413, 500]);
+
+function call(body: string, contentType = 'application/json') {
+  const request = new Request('http://localhost/api/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': contentType },
+    body,
+  });
+  return POST({ request } as Parameters<typeof POST>[0]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSendMail.mockResolvedValue({ messageId: '<id>' });
+  mockCreateTestAccount.mockResolvedValue({ user: 'u', pass: 'p' });
+  process.env.SMTP_HOST = 'smtp-relay';
+  process.env.SMTP_PORT = '25';
+  process.env.ALE_PERSONAL_EMAIL = 'ale@example.com';
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+/**
+ * Fault injection on the input boundary: throw arbitrary payloads at the
+ * endpoint and assert its residues survive — it never crashes, always answers
+ * with a sane HTTP status, and never sends mail unless it returns 200.
+ */
+describe('POST /api/contact fuzzing', () => {
+  it('always returns a Response with an allowed status for arbitrary JSON payloads', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.jsonValue(), async (payload) => {
+        const res = await call(JSON.stringify(payload));
+        expect(res).toBeInstanceOf(Response);
+        expect(ALLOWED_STATUSES.has(res.status)).toBe(true);
+      })
+    );
+  });
+
+  it('never throws on arbitrary (often non-JSON) raw bodies', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.string(), async (raw) => {
+        const res = await call(raw);
+        expect(res).toBeInstanceOf(Response);
+        expect(ALLOWED_STATUSES.has(res.status)).toBe(true);
+      })
+    );
+  });
+
+  it('only sends mail when it answers 200 (no mail for rejected input)', async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.jsonValue(), async (payload) => {
+        mockSendMail.mockClear();
+        const res = await call(JSON.stringify(payload));
+        if (res.status !== 200) {
+          expect(mockSendMail).not.toHaveBeenCalled();
+        }
+      })
+    );
+  });
+});

--- a/src/utils/posts.property.test.ts
+++ b/src/utils/posts.property.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import type { CollectionEntry } from 'astro:content';
+import { getLocalizedPostUrl, parsePostSlug } from './posts';
+
+const post = (id: string) => ({ id }) as CollectionEntry<'blog'>;
+const slugSegment = fc.stringMatching(/^[a-z0-9-]{1,20}$/);
+
+describe('posts properties', () => {
+  it('parsePostSlug always yields a supported language and a string slug, for any input', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.string(), fc.constantFrom(undefined)), (slug) => {
+        const { lang, cleanSlug } = parsePostSlug(slug);
+        return (lang === 'en' || lang === 'it') && typeof cleanSlug === 'string';
+      })
+    );
+  });
+
+  it('getLocalizedPostUrl always produces a /posts/ path; default lang has no prefix', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('en', 'it'), slugSegment, (lang, slug) => {
+        const url = getLocalizedPostUrl(post(`${lang}/${slug}`));
+        const expected = lang === 'en' ? `/posts/${slug}` : `/posts/${lang}/${slug}`;
+        return url === expected && url.startsWith('/posts/');
+      })
+    );
+  });
+
+  it('parsePostSlug round-trips an explicit lang prefix it produced', () => {
+    fc.assert(
+      fc.property(fc.constantFrom('en', 'it'), slugSegment, (lang, slug) => {
+        const parsed = parsePostSlug(`${lang}/${slug}`);
+        expect(parsed).toEqual({ lang, cleanSlug: slug });
+      })
+    );
+  });
+});

--- a/src/utils/reading-time.property.test.ts
+++ b/src/utils/reading-time.property.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { stripHtmlToPlainText, getReadingTime } from './reading-time';
+
+/**
+ * Property-based (residuality) tests: instead of a handful of examples, subject
+ * the functions to a wide space of random "stressor" strings and assert the
+ * invariants ("residues") that must survive every input.
+ */
+describe('reading-time properties', () => {
+  it('getReadingTime always returns a whole number of at least 1 minute', () => {
+    fc.assert(
+      fc.property(fc.string(), (content) => {
+        const minutes = getReadingTime(content);
+        return Number.isInteger(minutes) && minutes >= 1;
+      })
+    );
+  });
+
+  it('getReadingTime never throws and never returns NaN, even for unicode/whitespace', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.string(), fc.string({ unit: 'binary' }), fc.constantFrom('', '   ', '\n\t')), (content) => {
+        expect(Number.isFinite(getReadingTime(content))).toBe(true);
+      })
+    );
+  });
+
+  it('stripHtmlToPlainText returns a string with no complete HTML tags remaining', () => {
+    fc.assert(
+      fc.property(fc.string(), (content) => {
+        const out = stripHtmlToPlainText(content);
+        return typeof out === 'string' && !/<[^>]+>/.test(out);
+      })
+    );
+  });
+
+  it('stripHtmlToPlainText output is trimmed (no leading/trailing whitespace)', () => {
+    fc.assert(
+      fc.property(fc.string(), (content) => {
+        const out = stripHtmlToPlainText(content);
+        return out === out.trim();
+      })
+    );
+  });
+});

--- a/src/utils/referer.property.test.ts
+++ b/src/utils/referer.property.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { normalizeReferer } from './referer';
+
+describe('normalizeReferer properties', () => {
+  it('never throws and returns either null or a string for any input', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.string(), fc.constantFrom(null, undefined)), (input) => {
+        const out = normalizeReferer(input);
+        return out === null || typeof out === 'string';
+      })
+    );
+  });
+
+  it('strips query string and fragment from any valid URL', () => {
+    fc.assert(
+      fc.property(fc.webUrl({ withQueryParameters: true, withFragments: true }), (url) => {
+        const out = normalizeReferer(url);
+        // A valid URL always normalizes to a non-null origin+path with no ? or #.
+        return out !== null && !out.includes('?') && !out.includes('#');
+      })
+    );
+  });
+
+  it('is idempotent: normalizing an already-normalized referer is a no-op', () => {
+    fc.assert(
+      fc.property(fc.string(), (input) => {
+        const once = normalizeReferer(input);
+        if (once === null) return true;
+        expect(normalizeReferer(once)).toBe(once);
+        return true;
+      })
+    );
+  });
+});

--- a/src/utils/referer.ts
+++ b/src/utils/referer.ts
@@ -10,6 +10,10 @@ export function normalizeReferer(referer: string | null | undefined): string | n
   if (!referer) return null;
   try {
     const url = new URL(referer);
+    // Only http(s) referers are meaningful. Non-special schemes (e.g. "git:foo")
+    // have an opaque origin whose `url.origin` is the literal string "null", which
+    // would otherwise leak as a bogus referer value.
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
     const path = url.pathname === '/' ? '' : url.pathname;
     return url.origin + path;
   } catch {

--- a/src/utils/user-agent.property.test.ts
+++ b/src/utils/user-agent.property.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import fc from 'fast-check';
+import { parseUserAgent } from './user-agent';
+
+const BROWSERS = ['Chrome', 'Safari', 'Firefox', 'Edge', 'Opera', 'Other'];
+const OSES = ['iOS', 'Android', 'macOS', 'Windows', 'Linux', 'Other'];
+
+describe('parseUserAgent properties', () => {
+  it('always returns labels from the allowed low-cardinality sets (or null)', () => {
+    fc.assert(
+      fc.property(fc.oneof(fc.string(), fc.string({ unit: 'binary' }), fc.constantFrom(null, undefined)), (ua) => {
+        const { browser, os } = parseUserAgent(ua);
+        const browserOk = browser === null || BROWSERS.includes(browser);
+        const osOk = os === null || OSES.includes(os);
+        return browserOk && osOk;
+      })
+    );
+  });
+
+  it('returns both-null only for empty/nullish input, never partial null otherwise', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1 }), (ua) => {
+        const { browser, os } = parseUserAgent(ua);
+        // A non-empty UA always yields concrete labels (defaulting to 'Other').
+        return browser !== null && os !== null;
+      })
+    );
+  });
+
+  it('treats empty and nullish input as unknown (both null)', () => {
+    for (const input of ['', null, undefined]) {
+      expect(parseUserAgent(input)).toEqual({ browser: null, os: null });
+    }
+  });
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -5,7 +5,13 @@
  * Sets up in-memory database for testing.
  */
 import { beforeAll, afterEach, afterAll } from 'vitest';
+import fc from 'fast-check';
 import { server } from './src/mocks/server';
+
+// Property-based tests use a fixed seed so a failure is reproducible and the
+// gate is deterministic (no flaky CI). numRuns controls how many random
+// stressors each property is subjected to.
+fc.configureGlobal({ seed: 0x5eed, numRuns: 300 });
 
 // Configure in-memory database for tests
 process.env.DATABASE_PATH = ':memory:';


### PR DESCRIPTION
Phase 5 of the deterministic-gates journey. Instead of testing a few examples, subject functions to a wide space of random "stressors" and assert the invariants ("residues") that must survive every input.

- Add fast-check, configured with a fixed seed (reproducible / deterministic gate) and 300 runs per property in vitest.setup.ts.
- Property tests for the pure functions and parsers: reading-time, posts, referer, user-agent (no-throw, bounded output sets, idempotence, /posts/ path shape).
- Fault injection on the /api/contact boundary: arbitrary JSON and raw bodies always yield a Response with an allowed status, and mail is only sent on a 200 — the endpoint never crashes on garbage input.

A stressor immediately found a real residue gap: normalizeReferer returned the literal string "null" for opaque-origin URLs (e.g. "git:foo"), because URL.origin is "null" for non-special schemes. Fixed by restricting to http(s) referers; this also makes normalization idempotent.