### PR TITLE
DIY anti-bot defenses for the contact form

### DIFF
--- a/.agents/skills/teach/GLOSSARY-FORMAT.md
+++ b/.agents/skills/teach/GLOSSARY-FORMAT.md
@@ -1,0 +1,35 @@
+# GLOSSARY.md Format
+
+`GLOSSARY.md` is the canonical language for this teaching workspace. All explainers, exercises, and learning records should adhere to its terminology. Building it is itself part of learning: compressing a concept into a tight definition is evidence the user understands it.
+
+## Structure
+
+```md
+# {Topic} Glossary
+
+{One or two sentence description of the topic this glossary covers.}
+
+## Terms
+
+**Hypertrophy**:
+Muscle growth driven by mechanical tension and metabolic stress over repeated training sessions.
+_Avoid_: Bulking, getting big
+
+**Progressive overload**:
+Systematically increasing the demand on a muscle over time — via load, volume, or intensity.
+_Avoid_: Pushing harder, levelling up
+
+**RPE (Rate of Perceived Exertion)**:
+A 1–10 self-rating of how hard a set felt, where 10 is failure and 8 means two reps left in the tank.
+_Avoid_: Effort score, intensity rating
+```
+
+## Rules
+
+- **Add a term only when the user understands it.** The glossary is a record of compressed knowledge, not a dictionary the user reads to learn. If the user has just been introduced to a concept, wait until they can use it correctly before promoting it here.
+- **Be opinionated.** When several words exist for the same concept, pick the best one and list the rest as aliases to avoid. This is how language compresses.
+- **Keep definitions tight.** One or two sentences. Define what the term IS, not what it does or how to do it.
+- **Use the glossary's own terms inside definitions.** Once a term is in the glossary, prefer it everywhere — including inside other definitions. This is what makes complex terms easier to grasp later.
+- **Group under subheadings** when natural clusters emerge (e.g. `## Anatomy`, `## Programming`). A flat list is fine when terms cohere.
+- **Flag ambiguities explicitly.** If a term is used loosely in the wider field, note the resolution: "In this workspace, 'set' always means a working set — warm-ups are tracked separately."
+- **Revise as understanding deepens.** A definition the user wrote in week one may be wrong by week six. Update in place; do not leave stale entries.

--- a/.agents/skills/teach/LEARNING-RECORD-FORMAT.md
+++ b/.agents/skills/teach/LEARNING-RECORD-FORMAT.md
@@ -1,0 +1,46 @@
+# Learning Record Format
+
+Learning records live in `./learning-records/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc. Create the directory lazily — only when the first record is written.
+
+They are the teaching equivalent of ADRs: they capture non-obvious lessons, key insights, and stated prior knowledge that will steer future sessions. They are used to calculate the zone of proximal development.
+
+## Template
+
+```md
+# {Short title of what was learned or established}
+
+{1-3 sentences: what was learned (or what prior knowledge was established), and why it matters for future sessions.}
+```
+
+That is the whole format. A learning record can be a single paragraph. The value is recording _that_ this is now known and _why_ it changes what to teach next — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most records won't need them.
+
+- **Status** frontmatter (`active | superseded by LR-NNNN`) — useful when an earlier understanding turns out to be wrong and is replaced.
+- **Evidence** — how the user demonstrated the understanding (a question answered, an exercise completed, prior experience cited). Useful when the claim might be revisited.
+- **Implications** — what this unlocks or rules out for future sessions. Worth recording when non-obvious.
+
+## Numbering
+
+Scan `./learning-records/` for the highest existing number and increment by one.
+
+## When to write a learning record
+
+Write one when any of these is true:
+
+1. **The user demonstrated genuine understanding of something non-trivial** — not just exposure, but evidence they can use the concept correctly. This sets a new floor for what to teach next.
+2. **The user disclosed prior knowledge** — "I already know X." Record it so future sessions don't re-teach it. Also record the _depth_ claimed.
+3. **A misconception was corrected** — the user previously believed something wrong and now sees why. These are high-value: they predict future stumbling blocks for related topics.
+4. **The mission shifted in response to learning** — the user discovered they cared about something different than they thought. Cross-link to [[MISSION.md]] and update it.
+
+### What does _not_ qualify
+
+- Material that was merely covered. Coverage is not learning. Wait for evidence.
+- Anything already captured tersely in [[GLOSSARY.md]] as a term definition. Don't duplicate.
+- Session-by-session activity logs. Learning records are not a journal — they are decision-grade insights.
+
+## Supersession
+
+When a later record contradicts an earlier one (the user's understanding deepened or corrected), mark the old record `Status: superseded by LR-NNNN` rather than deleting it. The history of how understanding evolved is itself useful signal.

--- a/.agents/skills/teach/MISSION-FORMAT.md
+++ b/.agents/skills/teach/MISSION-FORMAT.md
@@ -1,0 +1,31 @@
+# MISSION.md Format
+
+`MISSION.md` lives at the workspace root. It captures the _reason_ the user is learning this topic. Every teaching decision — what to teach next, which resources to surface, which exercises to design — should trace back to this document.
+
+## Template
+
+```md
+# Mission: {Topic}
+
+## Why
+{1-3 sentences. The concrete real-world goal the user is chasing. What changes in their life or work when they have this skill? Avoid abstract framings like "to understand X" — push for the underlying outcome.}
+
+## Success looks like
+- {A specific, observable thing the user will be able to do}
+- {Another specific thing}
+- {…}
+
+## Constraints
+- {Time, budget, prior commitments, learning preferences, anything that bounds the approach}
+
+## Out of scope
+- {Adjacent topics the user explicitly does not want to chase right now — protects the zone of proximal development}
+```
+
+## Rules
+
+- **One mission per workspace.** If the user wants to learn two unrelated things, that is two workspaces.
+- **Concrete over abstract.** "Run a half marathon by October" beats "get fitter." "Ship a Rust CLI to my team" beats "learn Rust."
+- **Push back on vagueness.** If the user cannot articulate why, interview them before writing anything. A bad mission is worse than no mission.
+- **Revise when reality shifts.** Missions change. When the user's goal moves, update this file — don't leave a stale mission steering future sessions.
+- **Keep it short.** If `MISSION.md` runs past a screen, it has stopped being a compass and started being a plan.

--- a/.agents/skills/teach/RESOURCES-FORMAT.md
+++ b/.agents/skills/teach/RESOURCES-FORMAT.md
@@ -1,0 +1,32 @@
+# RESOURCES.md Format
+
+`RESOURCES.md` is the curated set of trusted sources for this topic. Knowledge for explainers should be drawn from here, not from parametric guesses. Wisdom comes from the communities listed here.
+
+## Structure
+
+```md
+# {Topic} Resources
+
+## Knowledge
+
+- [Book: _The Science and Practice of Strength Training_ — Zatsiorsky & Kraemer](https://example.com)
+  Foundational text on programming and adaptation. Use for: anything to do with periodisation, recovery, intensity zones.
+- [Article: "How Much Should I Train?" — Greg Nuckols (Stronger By Science)](https://example.com)
+  Evidence-based review of volume landmarks. Use for: weekly set targets per muscle group.
+
+## Wisdom (Communities)
+
+- [r/weightroom](https://reddit.com/r/weightroom)
+  High-signal subreddit, moderated against bro-science. Use for: programme critique, plateau troubleshooting.
+- Local: Tuesday strength class at {gym name}
+  Use for: real-time coaching feedback on lifts.
+```
+
+## Rules
+
+- **High-trust only.** Prefer primary sources, recognised experts, peer-reviewed work, and communities with strong moderation. If a resource is marketing dressed as education, leave it out.
+- **Annotate every entry.** A bare link is useless in three months. Add one line: what it covers and when to reach for it.
+- **Group by Knowledge / Wisdom.** Mirrors the philosophy in [SKILL.md](./SKILL.md). It is fine for a resource to appear in only one group.
+- **Surface gaps explicitly.** If no good resource exists for an area the mission needs, write a `## Gaps` section listing what is missing. This drives future search.
+- **Prune ruthlessly.** A resource that turned out to be wrong, shallow, or off-mission should be removed, not buried. Better five sharp sources than thirty mediocre ones.
+- **Record community preferences.** If the user has opted out of joining communities, note it here so future sessions don't keep proposing them.

--- a/.agents/skills/teach/SKILL.md
+++ b/.agents/skills/teach/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: teach
+description: Teach the user a new skill or concept, within this workspace.
+disable-model-invocation: true
+argument-hint: "What would you like to learn about?"
+---
+
+The user has asked you to teach them something. This is a stateful request - they intend to learn the topic over multiple sessions.
+
+## Teaching Workspace
+
+Treat the current directory as a teaching workspace. The state of their learning is captured in this directory in several files:
+
+- `MISSION.md`: A document capturing the _reason_ the user is interested in the topic. This should be used to ground all teaching. Use the format in [MISSION-FORMAT.md](./MISSION-FORMAT.md).
+- `./reference/*.html`: A directory of reference materials. These are the compressed learnings from the lessons - cheat sheets, reference algorithms, syntax, yoga poses, glossaries. They are the raw units of learning. They should be beautiful documents which print out well, and are designed for quick reference.
+- `RESOURCES.md`: A list of resources which can be explored to ground your teaching in contextual knowledge, or to acquire knowledge and wisdom. Use the format in [RESOURCES-FORMAT.md](./RESOURCES-FORMAT.md).
+- `./learning-records/*.md`: A directory of learning records, which capture what the user has learned. These are loosely equivalent to architectural decision records in software development - they capture non-obvious lessons and key insights that may need to be revised later, or drive future sessions. These should be used to calculate the zone of proximal development. They are titled `0001-<dash-case-name>.md`, where the number increments each time. Use the format in [LEARNING-RECORD-FORMAT.md](./LEARNING-RECORD-FORMAT.md).
+- `./lessons/*.html`: A directory of lessons. A **lesson** is a single, self-contained HTML output that teaches one tightly-scoped thing tied to the mission. This is the primary unit of teaching in this workspace.
+- `./assets/*`: Reusable **components** shared across lessons. See [Assets](#assets).
+- `NOTES.md`: A scratchpad for you to jot down user preferences, or working notes.
+
+## Philosophy
+
+To learn at a deep level, the user needs three things:
+
+- **Knowledge**, captured from high-quality, high-trust resources
+- **Skills**, acquired through highly-relevant interactive lessons devised by you, based on the knowledge
+- **Wisdom**, which comes from interacting with other learners and practitioners
+
+Before the `RESOURCES.md` is well-populated, your focus should be to find high-quality resources which will help the user acquire knowledge. Never trust your parametric knowledge.
+
+Some topics may require more skills than knowledge. Learning more about theoretical physics might be more knowledge-based. For yoga, more skills-based.
+
+### Fluency vs Storage Strength
+
+You should be careful to split between two types of learning:
+
+- **Fluency strength**: in-the-moment retrieval of knowledge
+- **Storage strength**: long-term retention of knowledge
+
+Fluency can give the user an illusory sense of mastery, but storage strength is the real goal. Try to design lessons which build long-term retention by desirable difficulty:
+
+- Using retrieval practice (recall from memory)
+- Spacing (distributing practice over time)
+- Interleaving (mixing up different but related topics in practice - for skills practice only)
+
+## Lessons
+
+A lesson is the main thing you produce — the unit in which knowledge and skills reach the user. Each lesson is one self-contained HTML file, saved to `./lessons/` and titled `0001-<dash-case-name>.html` where the number increments each time.
+
+A lesson should be **beautiful** — clean, readable typography and layout — since the user will return to these later to review. Think Tufte.
+
+The lesson should be short, and completable very quickly. Learners' working memory is very small, and we need to stay within it. But each lesson should give the user a single tangible win that they can build on. It should be directly tied to the mission, and should be in the user's zone of proximal development.
+
+If possible, open the lesson file for the user by running a CLI command.
+
+Each lesson should link via HTML anchors to other lessons and reference documents.
+
+Each lesson should recommend a primary source for the user to read or watch. This should be the most high-quality, high-trust resource you found on the topic.
+
+Each lesson should contain a reminder to ask followup questions to the agent. The agent is their teacher, and can assist with anything that's unclear.
+
+## Assets
+
+Lessons are built from reusable **components**, stored in `./assets/`: stylesheets, quiz widgets, simulators, diagram helpers — anything a second lesson could reuse.
+
+Reuse is the default, not the exception. Before authoring a lesson, read `./assets/` and build from the components already there. When a lesson needs something new and reusable, write it as a component in `./assets/` and link to it — never inline code a future lesson would duplicate.
+
+A shared stylesheet is the first component every workspace earns: every lesson links it, so the lessons look like one consistent course rather than a pile of one-offs. As the workspace grows, so should the component library.
+
+## The Mission
+
+Every lesson should be tied into the mission - the reason that the user is interested in learning about the topic.
+
+If the user is unclear about the mission, or the `MISSION.md` is not populated, your first job should be to question the user on why they want to learn this.
+
+Failing to understand the mission will mean knowledge acquisition is not grounded in real-world goals. Lessons will feel too abstract. You will have no way of judging what the user should do next.
+
+Missions may change as the user develops more skills and knowledge. This is normal - make sure to update the `MISSION.md` and add a learning record to capture the change. Confirm with the user before changing the mission.
+
+## Zone Of Proximal Development
+
+Each lesson, the user should always feel as if they are being challenged 'just enough'.
+
+The user may specify an exact thing they want to learn. If they don't, figure out their zone of proximal development by:
+
+- Reading their `learning-records`
+- Figuring out the right thing to teach them based on their mission
+- Teach the most relevant thing that fits in their zone of proximal development
+
+## Knowledge
+
+Lessons should be designed around a skill the user is going to learn. The knowledge in the lesson should be only what's required to acquire that skill. You teach the knowledge first, then get the user to practice the skills via an interactive feedback loop.
+
+Knowledge should first be gathered from trusted resources. Use `RESOURCES.md` to keep track of them. Lessons should be littered with citations - links to external resources to back up any claim made. This increases the trustworthiness of the lesson.
+
+For acquiring knowledge, difficulty is the enemy. It eats working memory you need for understanding.
+
+## Skills
+
+If knowledge is all about acquisition, skills are about durability and flexibility. Make the knowledge stick.
+
+For skill acquisition, difficulty is the tool. Effortful retrieval is what builds storage strength. Skills should be taught through interactive lessons. There are several tools at your disposal:
+
+- Interactive lessons, using quizzes and light in-browser tasks
+- Lessons which guide the user through a list of real-world steps to take (for instance, yoga poses)
+
+Each of these should be based on a **feedback loop**, where the user receives feedback on their performance. This feedback loop should be as tight as possible, giving feedback immediately - and ideally automatically.
+
+For quizzes, each answer should be exactly the same number of words (and characters, if possible). Don't give the user any clues about the answer through formatting.
+
+## Acquiring Wisdom
+
+Wisdom comes from true real-world interaction - testing your skills outside the learning environment.
+
+When the user asks a question that appears to require wisdom, your default posture should be to attempt to answer - but to ultimately delegate to a **community**.
+
+A community is a place (online or offline) where the user can test their skills in the real world. This might be a forum, a subreddit, a real-world class (budget permitting) or a local interest group.
+
+You should attempt to find high-reputation communities the user can join. If the user expresses a preference that they don't want to join a community, respect it.
+
+## Reference Documents
+
+While creating lessons, you should also create reference documents. Lessons can reference these documents - they are useful for tracking raw units of knowledge useful across lessons.
+
+Lessons will rarely be revisited later - reference documents will be. They should be the compressed essence of the lesson, in a format designed for quick reference.
+
+Some learning topics lend themselves to reference:
+
+- Syntax and code snippets for programming
+- Algorithms and flowcharts for processes
+- Yoga poses and sequences for yoga
+- Exercises and routines for fitness
+- Glossaries for any topic with its own nomenclature
+
+Glossaries, in particular, are an essential reference. Once one is created, it should be adhered to in every lesson.
+
+## `NOTES.md`
+
+The user will sometimes express preferences of how they want to be taught, or things you should keep in mind. This is the place to record those preferences, so you can refer back to them when designing lessons or working with the user.

--- a/.agents/skills/teach/agents/openai.yaml
+++ b/.agents/skills/teach/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Teach"
+  short_description: "Learn a concept in a guided workspace"
+policy:
+  allow_implicit_invocation: false

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,12 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(grep -oE \"^[^ ]+\\\\.\\(ts|astro\\):[0-9]+:[0-9]+ - error[^$]*\")",
+      "Bash(git commit *)",
+      "Bash(gh auth *)",
+      "Bash(npx skills *)"
+    ]
+  },
   "enabledPlugins": {
     "mattpocock-skills@mattpocock": true
   }

--- a/.claude/skills/teach
+++ b/.claude/skills/teach
@@ -1,0 +1,1 @@
+../../.agents/skills/teach

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# aleromano.com
+
+Personal website and blog of Alessandro Romano: bilingual (EN/IT) content, a contact
+form that exists to win consultancy/mentoring leads, and self-hosted infrastructure
+with a strict no-third-party-services stance.
+
+## Language
+
+### Contact
+
+**Lead**:
+A genuine human submission through the contact form — the asset the form exists to capture.
+_Avoid_: message, inquiry, request
+
+**Noise**:
+A non-human or junk submission that reaches the inbox. Deletable in one keystroke; never worth losing a Lead to prevent.
+_Avoid_: spam (too broad — email spam is a different problem)
+
+**Contact Reason**:
+The sender's declared purpose, chosen from a fixed list (consultancy, mentoring, job, blogpost, general, problems). Drives form behaviour and email subject.
+_Avoid_: category, topic
+
+**Form Token**:
+A time-stamped, site-issued proof that the sender obtained it from this site and waited a human-plausible interval before submitting. Replayable within its validity window; expires on deploy.
+_Avoid_: CSRF token, captcha, nonce (implies single-use)
+
+**Honeypot**:
+A decoy field that honest clients always send empty. Part of the API contract: missing or filled means the sender is not the honest client.
+_Avoid_: trap field, hidden field
+
+**Tripwire Rejection**:
+Refusing a submission that failed a bot check, with a deliberately generic error that teaches the sender nothing.
+_Avoid_: validation error (that's for Human Mistakes)
+
+**Human Mistake**:
+A submission flaw a genuine person can fix (e.g. a typo'd email address). Gets precise, bilingual, actionable feedback — the opposite register from a Tripwire Rejection.

--- a/docs/adr/0001-stateless-fail-open-contact-form-defenses.md
+++ b/docs/adr/0001-stateless-fail-open-contact-form-defenses.md
@@ -1,0 +1,38 @@
+# Stateless, fail-open anti-bot defenses for the contact form
+
+After receiving low-effort bot spam, we added DIY (no third-party) defenses to
+`POST /api/contact`. Guiding principle: **never lose a Lead to fight Noise** — the
+form exists to win consultancy work; junk email costs one keystroke to delete.
+Flood protection already exists in nginx (`limit_req`, 5r/m); the app layer only
+has to make a *single* bot submission fail.
+
+## Decisions
+
+- **Enforcement lives in the API, not the form.** The observed bot may never have
+  rendered our HTML; the form is just the honest client of a defended API.
+- **Honeypot as API contract**: the decoy field must be *present and empty*.
+  Absent (direct API scripts) and filled (form-filler bots) both fail.
+- **Form Token, stateless and replayable**: HMAC-signed timestamp issued by a
+  dedicated endpoint; the API enforces a minimum age (humans take seconds to type)
+  and maximum age. No consumed-token storage — replay within the window is
+  accepted because nginx caps the blast radius. Persistence for rate limiting
+  belongs to nginx, not the app.
+- **Ephemeral signing secret**, generated in-memory at process startup. No env var
+  to provision and no unset-secret failure mode; deploys invalidate outstanding
+  tokens, and the honest client heals by refetching and retrying once.
+  **Assumption: single Node process.** Multiple instances would each hold a
+  different secret — revisit this ADR before scaling out.
+- **Email validation is for Human Mistakes, not bots**: server-side syntax check
+  plus MX lookup via `node:dns`. **Fails open** — DNS trouble accepts the
+  submission, because rejecting a possibly-real Lead is worse than admitting Noise.
+- **Two error registers**: Tripwire Rejections return an honest-but-generic 400
+  (no silent-success spamtrap: its failure mode is Leads vanishing invisibly);
+  Human Mistakes get precise bilingual messages.
+
+## Rejected alternatives
+
+- **Visible CAPTCHA**: friction for humans, trivially solvable for bots.
+- **Proof-of-work**: costs real phones battery, costs attackers pennies.
+- **SMTP callout verification**: risks blacklisting the VPS IP that sends our own mail.
+- **Email confirmation loop**: adds a click between a prospective client and us.
+- **Silent-success on bot detection**: misconfiguration would silently discard Leads.

--- a/nginx/prod.conf
+++ b/nginx/prod.conf
@@ -183,6 +183,23 @@ server {
         add_header Cache-Control "no-store";
     }
 
+    # Anti-bot token for the contact form - shares the CONTACT budget so
+    # token fetch + submit stay within one visitor's allowance
+    location = /api/contact-token {
+        limit_req zone=CONTACT burst=3 nodelay;
+        limit_req_status 429;
+
+        set $app_upstream app:4321;
+        proxy_pass http://$app_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+
+        add_header Cache-Control "no-store";
+    }
+
     # Analytics collect endpoint - rate limited, Origin enforced at app level
     location = /api/analytics/collect {
         limit_req zone=ANALYTICS burst=20 nodelay;

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "teach": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/productivity/teach/SKILL.md",
+      "computedHash": "68999bb1a241384b2f921f3321d779b7d05eb6089077b70d88cee2aee3d75ccc"
+    }
+  }
+}

--- a/src/components/pages/BaseContact.astro
+++ b/src/components/pages/BaseContact.astro
@@ -35,6 +35,8 @@ export interface ContactTranslations {
         success: string;
         error: string;
         networkError: string;
+        emailSyntax: string;
+        emailDomain: string;
     };
 }
 
@@ -75,6 +77,8 @@ export const contactTranslations: Record<SupportedLanguage, ContactTranslations>
             success: 'Your message has been sent successfully!',
             error: 'An error occurred. Please try again.',
             networkError: 'An unexpected error occurred. Please check your connection and try again.',
+            emailSyntax: "That email address doesn't look right. Please double-check it.",
+            emailDomain: "That email's domain doesn't seem to receive mail. Is it spelled correctly?",
         },
     },
     it: {
@@ -114,6 +118,8 @@ export const contactTranslations: Record<SupportedLanguage, ContactTranslations>
             success: 'Il tuo messaggio è stato inviato con successo!',
             error: 'Si è verificato un errore. Riprova.',
             networkError: 'Si è verificato un errore imprevisto. Controlla la connessione e riprova.',
+            emailSyntax: "Quell'indirizzo email non sembra corretto. Ricontrollalo.",
+            emailDomain: "Il dominio di quell'email non sembra ricevere posta. È scritto correttamente?",
         },
     },
 };
@@ -164,6 +170,12 @@ const clientTexts = {
         </div>
 
         <fieldset id="formFields" disabled>
+            <!-- Honeypot: humans never see it; the API requires it present and empty -->
+            <div class="contact-extra" aria-hidden="true">
+                <label for="website">Website</label>
+                <input type="text" id="website" name="website" tabindex="-1" autocomplete="off" />
+            </div>
+
             <div class="form-group">
                 <label for="name">{t.formLabels.name}</label>
                 <input type="text" id="name" name="name" required />
@@ -203,7 +215,8 @@ const clientTexts = {
         linkifyUrls,
         buildSubmissionPayload,
         parseReasonPreselection,
-        submitContactForm,
+        fetchContactToken,
+        submitWithTokenRecovery,
         type SubmitMessages,
     } from './contact-form';
 
@@ -269,8 +282,18 @@ const clientTexts = {
             submitButton.textContent = submitting ? texts.submittingLabel : texts.submitLabel;
         }
 
+        // Form Token: fetched on first interaction so it is already past its
+        // minimum age by the time a human finishes typing.
+        let tokenPromise: Promise<string | null> | null = null;
+        function ensureToken(): Promise<string | null> {
+            tokenPromise ??= fetchContactToken();
+            return tokenPromise;
+        }
+        form.addEventListener('focusin', ensureToken, { once: true });
+
         reasonSelect.addEventListener('change', () => {
             hideStatus();
+            ensureToken();
             applyReason(reasonSelect.value);
         });
 
@@ -280,7 +303,9 @@ const clientTexts = {
             setSubmitting(true);
 
             const payload = buildSubmissionPayload(Object.fromEntries(new FormData(form)));
-            const outcome = await submitContactForm(payload, texts.messages);
+            const token = await ensureToken();
+            const outcome = await submitWithTokenRecovery(payload, token, texts.messages);
+            if (outcome.code === 'invalid-token') tokenPromise = null;
 
             setSubmitting(false);
             if (outcome.success) resetForm();
@@ -322,6 +347,15 @@ const clientTexts = {
 
     .form-group {
         margin-bottom: var(--space-md);
+    }
+
+    /* Honeypot: moved off-screen rather than display:none, which naive bots detect */
+    .contact-extra {
+        position: absolute;
+        left: -9999px;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
     }
 
     label {

--- a/src/components/pages/contact-form.test.ts
+++ b/src/components/pages/contact-form.test.ts
@@ -8,6 +8,9 @@ import {
     buildSubmissionPayload,
     parseReasonPreselection,
     submitContactForm,
+    fetchContactToken,
+    submitWithTokenRecovery,
+    TOKEN_RETRY_WAIT_MS,
 } from './contact-form';
 
 describe('getReasonView', () => {
@@ -133,6 +136,8 @@ describe('submitContactForm', () => {
         success: 'fallback success',
         error: 'fallback error',
         networkError: 'network down',
+        emailSyntax: 'check that email',
+        emailDomain: 'that domain gets no mail',
     };
     const endpoint = 'http://localhost/api/contact';
     const payload = { reason: 'general', name: 'Ada', email: 'ada@example.com', message: 'Hi' };
@@ -181,5 +186,137 @@ describe('submitContactForm', () => {
             success: false,
             message: 'network down',
         });
+    });
+
+    it('maps Human Mistake codes to localized messages, ignoring the server wording', async () => {
+        server.use(
+            http.post(endpoint, () =>
+                HttpResponse.json(
+                    { success: false, message: 'English-only server text', code: 'email-syntax' },
+                    { status: 400 }
+                )
+            )
+        );
+        const outcome = await submitContactForm(payload, messages, endpoint);
+        expect(outcome.message).toBe('check that email');
+        expect(outcome.code).toBe('email-syntax');
+    });
+});
+
+describe('fetchContactToken', () => {
+    const tokenEndpoint = 'http://localhost/api/contact-token';
+
+    it('returns the token from the endpoint', async () => {
+        server.use(http.get(tokenEndpoint, () => HttpResponse.json({ token: 'abc.def' })));
+        expect(await fetchContactToken(tokenEndpoint)).toBe('abc.def');
+    });
+
+    it('returns null on an error response', async () => {
+        server.use(http.get(tokenEndpoint, () => HttpResponse.json({}, { status: 500 })));
+        expect(await fetchContactToken(tokenEndpoint)).toBeNull();
+    });
+
+    it('returns null when the request cannot complete', async () => {
+        server.use(http.get(tokenEndpoint, () => HttpResponse.error()));
+        expect(await fetchContactToken(tokenEndpoint)).toBeNull();
+    });
+});
+
+describe('submitWithTokenRecovery', () => {
+    const messages = {
+        success: 'sent',
+        error: 'failed',
+        networkError: 'network down',
+        emailSyntax: 'check that email',
+        emailDomain: 'that domain gets no mail',
+    };
+    const endpoint = 'http://localhost/api/contact';
+    const payload = { reason: 'general', name: 'Ada', email: 'ada@example.com', message: 'Hi', website: '' };
+
+    function captureSubmittedTokens(respond: (token: unknown) => Response) {
+        const tokens: unknown[] = [];
+        server.use(
+            http.post(endpoint, async ({ request }) => {
+                const body = (await request.json()) as Record<string, unknown>;
+                tokens.push(body.token);
+                return respond(body.token);
+            })
+        );
+        return tokens;
+    }
+
+    it('submits once with the provided token when the server accepts it', async () => {
+        const tokens = captureSubmittedTokens(() => HttpResponse.json({ success: true, message: 'ok' }));
+
+        const outcome = await submitWithTokenRecovery(payload, 'good-token', messages, { endpoint });
+
+        expect(outcome.success).toBe(true);
+        expect(tokens).toEqual(['good-token']);
+    });
+
+    it('refetches, waits out the minimum age, and retries once on a stale token', async () => {
+        const tokens = captureSubmittedTokens((token) =>
+            token === 'fresh-token'
+                ? HttpResponse.json({ success: true, message: 'ok' })
+                : HttpResponse.json({ success: false, message: 'Invalid submission.', code: 'invalid-token' }, { status: 400 })
+        );
+        const waits: number[] = [];
+
+        const outcome = await submitWithTokenRecovery(payload, 'stale-token', messages, {
+            endpoint,
+            fetchToken: async () => 'fresh-token',
+            wait: async (ms) => void waits.push(ms),
+        });
+
+        expect(outcome.success).toBe(true);
+        expect(tokens).toEqual(['stale-token', 'fresh-token']);
+        expect(waits).toEqual([TOKEN_RETRY_WAIT_MS]);
+    });
+
+    it('gives up after one retry when the server keeps rejecting', async () => {
+        const tokens = captureSubmittedTokens(() =>
+            HttpResponse.json({ success: false, message: 'Invalid submission.', code: 'invalid-token' }, { status: 400 })
+        );
+
+        const outcome = await submitWithTokenRecovery(payload, null, messages, {
+            endpoint,
+            fetchToken: async () => 'fresh-token',
+            wait: async () => {},
+        });
+
+        expect(outcome.success).toBe(false);
+        expect(tokens).toEqual(['', 'fresh-token']);
+    });
+
+    it('does not retry when the failure is not token-related', async () => {
+        const tokens = captureSubmittedTokens(() =>
+            HttpResponse.json({ success: false, message: 'nope', code: 'email-syntax' }, { status: 400 })
+        );
+
+        const outcome = await submitWithTokenRecovery(payload, 'good-token', messages, {
+            endpoint,
+            fetchToken: async () => 'fresh-token',
+            wait: async () => {},
+        });
+
+        expect(outcome.success).toBe(false);
+        expect(outcome.message).toBe('check that email');
+        expect(tokens).toEqual(['good-token']);
+    });
+
+    it('returns the original failure when no fresh token can be fetched', async () => {
+        const tokens = captureSubmittedTokens(() =>
+            HttpResponse.json({ success: false, message: 'Invalid submission.', code: 'invalid-token' }, { status: 400 })
+        );
+
+        const outcome = await submitWithTokenRecovery(payload, 'stale-token', messages, {
+            endpoint,
+            fetchToken: async () => null,
+            wait: async () => {},
+        });
+
+        expect(outcome.success).toBe(false);
+        expect(outcome.code).toBe('invalid-token');
+        expect(tokens).toEqual(['stale-token']);
     });
 });

--- a/src/components/pages/contact-form.ts
+++ b/src/components/pages/contact-form.ts
@@ -88,11 +88,25 @@ export interface SubmitMessages {
     success: string;
     error: string;
     networkError: string;
+    emailSyntax: string;
+    emailDomain: string;
 }
 
 export interface SubmitOutcome {
     success: boolean;
     message: string;
+    /** Machine-readable error code from the API, when it sent one */
+    code?: string;
+}
+
+/**
+ * The API answers Human Mistakes with a machine-readable code; the client owns
+ * the localized wording. Unknown codes fall back to the server message.
+ */
+function failureMessage(code: unknown, serverMessage: unknown, messages: SubmitMessages): string {
+    if (code === 'email-syntax') return messages.emailSyntax;
+    if (code === 'email-domain') return messages.emailDomain;
+    return typeof serverMessage === 'string' && serverMessage ? serverMessage : messages.error;
 }
 
 export async function submitContactForm(
@@ -112,8 +126,59 @@ export async function submitContactForm(
         if (response.ok && result.success) {
             return { success: true, message: result.message || messages.success };
         }
-        return { success: false, message: result.message || messages.error };
+        return {
+            success: false,
+            message: failureMessage(result.code, result.message, messages),
+            ...(typeof result.code === 'string' ? { code: result.code } : {}),
+        };
     } catch {
         return { success: false, message: messages.networkError };
     }
+}
+
+export const TOKEN_ENDPOINT = '/api/contact-token';
+
+/** The API refuses tokens younger than 3s; wait a hair longer before retrying. */
+export const TOKEN_RETRY_WAIT_MS = 3_500;
+
+export async function fetchContactToken(endpoint = TOKEN_ENDPOINT): Promise<string | null> {
+    try {
+        const response = await fetch(endpoint);
+        if (!response.ok) return null;
+        const result = await response.json();
+        return typeof result.token === 'string' ? result.token : null;
+    } catch {
+        return null;
+    }
+}
+
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export interface TokenRecoveryDeps {
+    fetchToken?: () => Promise<string | null>;
+    wait?: (ms: number) => Promise<void>;
+    endpoint?: string;
+}
+
+/**
+ * Submits with the given Form Token. A deploy rotates the server's signing
+ * secret, invalidating tokens already handed out — on that rejection, fetch a
+ * fresh token, wait out the minimum token age, and retry once, invisibly.
+ */
+export async function submitWithTokenRecovery(
+    payload: Record<string, FormDataEntryValue>,
+    token: string | null,
+    messages: SubmitMessages,
+    deps: TokenRecoveryDeps = {}
+): Promise<SubmitOutcome> {
+    const { fetchToken = fetchContactToken, wait = sleep, endpoint } = deps;
+
+    const outcome = await submitContactForm({ ...payload, token: token ?? '' }, messages, endpoint);
+    if (outcome.success || outcome.code !== 'invalid-token') return outcome;
+
+    const freshToken = await fetchToken();
+    if (!freshToken) return outcome;
+
+    await wait(TOKEN_RETRY_WAIT_MS);
+    return submitContactForm({ ...payload, token: freshToken }, messages, endpoint);
 }

--- a/src/pages/api/contact-token.test.ts
+++ b/src/pages/api/contact-token.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from './contact-token';
+import { verifyToken, TOKEN_MIN_AGE_MS } from '../../utils/contact-token';
+
+function call() {
+  const request = new Request('http://localhost/api/contact-token');
+  return GET({ request } as Parameters<typeof GET>[0]);
+}
+
+describe('GET /api/contact-token', () => {
+  it('returns a token that the verifier accepts once the minimum age has passed', async () => {
+    const response = await call();
+
+    expect(response.status).toBe(200);
+    const { token } = await response.json();
+    expect(verifyToken(token, Date.now() + TOKEN_MIN_AGE_MS)).toEqual({ valid: true });
+  });
+
+  it('forbids caching, which would serve expired tokens', async () => {
+    const response = await call();
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+});

--- a/src/pages/api/contact-token.ts
+++ b/src/pages/api/contact-token.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+import { issueToken } from '../../utils/contact-token';
+
+/**
+ * Issues the Form Token that POST /api/contact requires. Fetched by the
+ * contact form on first interaction; rate-limited by nginx like /api/contact.
+ */
+export const GET: APIRoute = async () => {
+  return new Response(JSON.stringify({ token: issueToken() }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      // A cached token would eventually be served past its max age.
+      'Cache-Control': 'no-store',
+    },
+  });
+};

--- a/src/pages/api/contact.property.test.ts
+++ b/src/pages/api/contact.property.test.ts
@@ -84,4 +84,17 @@ describe('POST /api/contact fuzzing', () => {
       })
     );
   });
+
+  it('never accepts a payload lacking a genuine Form Token (anti-bot residue)', async () => {
+    // fc cannot forge an HMAC over the process secret, so no generated payload
+    // may ever reach the mailer — the tripwires must catch every one.
+    await fc.assert(
+      fc.asyncProperty(fc.jsonValue(), async (payload) => {
+        mockSendMail.mockClear();
+        const res = await call(JSON.stringify(payload));
+        expect(res.status).not.toBe(200);
+        expect(mockSendMail).not.toHaveBeenCalled();
+      })
+    );
+  });
 });

--- a/src/pages/api/contact.test.ts
+++ b/src/pages/api/contact.test.ts
@@ -21,15 +21,28 @@ vi.mock('nodemailer', () => ({
   },
 }));
 
+// Real DNS has no place in unit tests: the MX check sees a well-published domain.
+const { mockResolveMx } = vi.hoisted(() => ({ mockResolveMx: vi.fn() }));
+vi.mock('node:dns/promises', () => ({ resolveMx: mockResolveMx }));
+
 import { POST } from './contact';
+import { issueToken, TOKEN_MIN_AGE_MS } from '../../utils/contact-token';
 
 const RECIPIENT = 'ale@example.com';
 
+/** A token old enough to clear the minimum-age check right now. */
+function matureToken(): string {
+  return issueToken(Date.now() - TOKEN_MIN_AGE_MS);
+}
+
+// Object bodies get a valid Form Token unless the test supplies its own.
 function makeRequest(body: unknown, headers: Record<string, string> = {}): Request {
+  const withToken =
+    body !== null && typeof body === 'object' && !('token' in body) ? { token: matureToken(), ...body } : body;
   return new Request('http://localhost/api/contact', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...headers },
-    body: typeof body === 'string' ? body : JSON.stringify(body),
+    body: typeof withToken === 'string' ? withToken : JSON.stringify(withToken),
   });
 }
 
@@ -38,11 +51,13 @@ function call(request: Request) {
   return POST({ request } as Parameters<typeof POST>[0]);
 }
 
+// `website` is the Honeypot: honest clients always send it empty.
 const validPayload = {
   reason: 'general',
   name: 'Jane Doe',
   email: 'jane@external.com',
   message: 'Hello there\nsecond line',
+  website: '',
 };
 
 const ORIGINAL_ENV = { ...process.env };
@@ -52,6 +67,7 @@ beforeEach(() => {
   mockSendMail.mockResolvedValue({ messageId: '<test-message-id>' });
   mockCreateTestAccount.mockResolvedValue({ user: 'ethereal-user', pass: 'ethereal-pass' });
   mockGetTestMessageUrl.mockReturnValue('https://ethereal.email/message/preview');
+  mockResolveMx.mockResolvedValue([{ exchange: 'mx.external.com', priority: 10 }]);
   // Production-like config: route through the internal relay, not Ethereal.
   process.env.SMTP_HOST = 'smtp-relay';
   process.env.SMTP_PORT = '25';
@@ -155,7 +171,7 @@ describe('POST /api/contact', () => {
     });
 
     it('rejects a submission missing required fields with 400 listing them', async () => {
-      const response = await call(makeRequest({ reason: 'general', name: '', email: '', message: '' }));
+      const response = await call(makeRequest({ reason: 'general', name: '', email: '', message: '', website: '' }));
 
       expect(response.status).toBe(400);
       const json = await response.json();
@@ -170,6 +186,86 @@ describe('POST /api/contact', () => {
 
       expect(response.status).toBe(400);
       expect(mockSendMail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('bot tripwires (generic 400, no email is sent)', () => {
+    const TRIPWIRE_MESSAGE = 'Invalid submission.';
+
+    it('rejects when the honeypot field is missing entirely (direct API scripts)', async () => {
+      const { website: _website, ...withoutHoneypot } = validPayload;
+      const response = await call(makeRequest(withoutHoneypot));
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.message).toBe(TRIPWIRE_MESSAGE);
+      expect(mockSendMail).not.toHaveBeenCalled();
+    });
+
+    it('rejects when the honeypot field is filled (form-filler bots)', async () => {
+      const response = await call(makeRequest({ ...validPayload, website: 'https://spam.example' }));
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.message).toBe(TRIPWIRE_MESSAGE);
+      expect(mockSendMail).not.toHaveBeenCalled();
+    });
+
+    it('rejects a missing token with the invalid-token code so the client can retry', async () => {
+      const response = await call(makeRequest({ ...validPayload, token: undefined }));
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.message).toBe(TRIPWIRE_MESSAGE);
+      expect(json.code).toBe('invalid-token');
+      expect(mockSendMail).not.toHaveBeenCalled();
+    });
+
+    it('rejects a forged token', async () => {
+      const response = await call(makeRequest({ ...validPayload, token: '1700000000000.' + 'a'.repeat(64) }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).code).toBe('invalid-token');
+      expect(mockSendMail).not.toHaveBeenCalled();
+    });
+
+    it('rejects a token submitted faster than a human could type a message', async () => {
+      const response = await call(makeRequest({ ...validPayload, token: issueToken(Date.now()) }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).code).toBe('invalid-token');
+      expect(mockSendMail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('email plausibility (specific feedback, no email is sent)', () => {
+    it('rejects a syntactically broken email with the email-syntax code', async () => {
+      const response = await call(makeRequest({ ...validPayload, email: 'jane@gmailcom' }));
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('email-syntax');
+      expect(mockSendMail).not.toHaveBeenCalled();
+    });
+
+    it('rejects an email whose domain does not exist with the email-domain code', async () => {
+      mockResolveMx.mockRejectedValue(Object.assign(new Error('ENOTFOUND'), { code: 'ENOTFOUND' }));
+
+      const response = await call(makeRequest({ ...validPayload, email: 'jane@gmali.com' }));
+
+      expect(response.status).toBe(400);
+      const json = await response.json();
+      expect(json.code).toBe('email-domain');
+      expect(mockSendMail).not.toHaveBeenCalled();
+    });
+
+    it('accepts the submission when DNS fails for uncertain reasons (fail open)', async () => {
+      mockResolveMx.mockRejectedValue(Object.assign(new Error('SERVFAIL'), { code: 'SERVFAIL' }));
+
+      const response = await call(makeRequest(validPayload));
+
+      expect(response.status).toBe(200);
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/pages/api/contact.ts
+++ b/src/pages/api/contact.ts
@@ -1,5 +1,7 @@
 import type { APIRoute } from 'astro';
 import nodemailer from 'nodemailer';
+import { verifyToken } from '../../utils/contact-token';
+import { isPlausibleEmail, domainAcceptsMail } from '../../utils/email-validation';
 
 // Define HTTP status codes
 const HTTP_OK = 200;
@@ -10,8 +12,15 @@ const HTTP_INTERNAL_SERVER_ERROR = 500;
 interface ApiResponseData {
   success: boolean;
   message: string;
+  /** Machine-readable error code the client maps to a localized message */
+  code?: string;
   data?: unknown; // Optional field for additional data
 }
+
+// Tripwire Rejections deliberately share one generic message: a bot author
+// must not learn which check caught them. Humans never see it — the honest
+// client always sends the honeypot empty and retries on invalid-token.
+const TRIPWIRE_MESSAGE = 'Invalid submission.';
 
 // Helper function to create standardized JSON responses
 function createJsonResponse(responseData: ApiResponseData, status: number): Response {
@@ -105,7 +114,26 @@ export const POST: APIRoute = async ({ request }) => {
       return createJsonResponse({ success: false, message: "Invalid JSON." }, HTTP_BAD_REQUEST);
     }
 
-    const { reason, name, email, message, blogPostTitle } = data;
+    if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+      return createJsonResponse({ success: false, message: "Invalid JSON." }, HTTP_BAD_REQUEST);
+    }
+
+    const { reason, name, email, message, blogPostTitle, website, token } = data;
+
+    // Honeypot: the honest client always sends `website`, always empty.
+    if (typeof website !== 'string' || website !== '') {
+      console.warn('Contact tripwire: honeypot', { present: website !== undefined });
+      return createJsonResponse({ success: false, message: TRIPWIRE_MESSAGE }, HTTP_BAD_REQUEST);
+    }
+
+    const tokenResult = verifyToken(typeof token === 'string' ? token : '');
+    if (!tokenResult.valid) {
+      console.warn('Contact tripwire: token', { reason: tokenResult.reason });
+      return createJsonResponse(
+        { success: false, message: TRIPWIRE_MESSAGE, code: 'invalid-token' },
+        HTTP_BAD_REQUEST
+      );
+    }
 
     if (typeof reason !== 'string' || !reason) {
       return createJsonResponse({ success: false, message: "Contact reason is required." }, HTTP_BAD_REQUEST);
@@ -133,6 +161,22 @@ export const POST: APIRoute = async ({ request }) => {
 
     if (blogPostTitle !== undefined && (typeof blogPostTitle !== 'string' || blogPostTitle.length > MAX_BLOG_POST_TITLE_LENGTH)) {
       return createJsonResponse({ success: false, message: "Blog post title is invalid or exceeds the maximum allowed length." }, HTTP_BAD_REQUEST);
+    }
+
+    // Human Mistake checks: specific feedback so a real sender can fix a typo'd
+    // address. The MX lookup fails open — DNS uncertainty must not cost a lead.
+    if (!isPlausibleEmail(email)) {
+      return createJsonResponse(
+        { success: false, message: "That email address doesn't look right. Please double-check it.", code: 'email-syntax' },
+        HTTP_BAD_REQUEST
+      );
+    }
+
+    if (!(await domainAcceptsMail(email))) {
+      return createJsonResponse(
+        { success: false, message: "The domain of that email address doesn't seem to receive mail. Is it spelled correctly?", code: 'email-domain' },
+        HTTP_BAD_REQUEST
+      );
     }
 
     const PERSONAL_EMAIL = import.meta.env.ALE_PERSONAL_EMAIL || process.env.ALE_PERSONAL_EMAIL;

--- a/src/utils/contact-token.test.ts
+++ b/src/utils/contact-token.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { issueToken, verifyToken, TOKEN_MIN_AGE_MS, TOKEN_MAX_AGE_MS } from './contact-token';
+
+const ISSUED_AT = 1_700_000_000_000;
+
+describe('contact form token', () => {
+  it('accepts its own token once the minimum age has passed', () => {
+    const token = issueToken(ISSUED_AT);
+
+    const result = verifyToken(token, ISSUED_AT + TOKEN_MIN_AGE_MS);
+
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('rejects a token younger than the minimum age (bots submit instantly)', () => {
+    const token = issueToken(ISSUED_AT);
+
+    const result = verifyToken(token, ISSUED_AT + TOKEN_MIN_AGE_MS - 1);
+
+    expect(result).toEqual({ valid: false, reason: 'too-young' });
+  });
+
+  it('rejects a token older than the maximum age (stale or replayed much later)', () => {
+    const token = issueToken(ISSUED_AT);
+
+    const result = verifyToken(token, ISSUED_AT + TOKEN_MAX_AGE_MS + 1);
+
+    expect(result).toEqual({ valid: false, reason: 'too-old' });
+  });
+
+  it('rejects a token whose timestamp was tampered with', () => {
+    const token = issueToken(ISSUED_AT);
+    const [, signature] = token.split('.');
+    const forged = `${ISSUED_AT - 60_000}.${signature}`;
+
+    const result = verifyToken(forged, ISSUED_AT);
+
+    expect(result).toEqual({ valid: false, reason: 'bad-signature' });
+  });
+
+  it('rejects a token with a forged signature', () => {
+    const token = issueToken(ISSUED_AT);
+    const [timestamp, signature] = token.split('.');
+    const flipped = (signature[0] === 'a' ? 'b' : 'a') + signature.slice(1);
+
+    const result = verifyToken(`${timestamp}.${flipped}`, ISSUED_AT + TOKEN_MIN_AGE_MS);
+
+    expect(result).toEqual({ valid: false, reason: 'bad-signature' });
+  });
+
+  it.each([
+    ['empty string', ''],
+    ['no separator', 'abcdef'],
+    ['non-numeric timestamp', 'notanumber.deadbeef'],
+    ['missing signature', '1700000000000.'],
+    ['signature of wrong length', '1700000000000.deadbeef'],
+  ])('rejects a malformed token: %s', (_label, malformed) => {
+    const result = verifyToken(malformed, ISSUED_AT);
+
+    expect(result).toEqual({ valid: false, reason: 'malformed' });
+  });
+
+  it('rejects a token dated in the future (forged timestamp cannot skip the wait)', () => {
+    const token = issueToken(ISSUED_AT + 60_000);
+
+    const result = verifyToken(token, ISSUED_AT);
+
+    expect(result).toEqual({ valid: false, reason: 'too-young' });
+  });
+
+  it('issues distinct tokens for distinct timestamps', () => {
+    expect(issueToken(ISSUED_AT)).not.toBe(issueToken(ISSUED_AT + 1));
+  });
+});

--- a/src/utils/contact-token.ts
+++ b/src/utils/contact-token.ts
@@ -1,0 +1,56 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Anti-bot Form Token: an HMAC-signed timestamp proving the sender fetched it
+ * from this site and waited a human-plausible interval before submitting.
+ *
+ * Deliberately stateless and replayable within its window — nginx rate limiting
+ * caps abuse. See docs/adr/0001-stateless-fail-open-contact-form-defenses.md.
+ *
+ * The secret is ephemeral (regenerated per process start), so a deploy
+ * invalidates outstanding tokens. The form heals by refetching and retrying.
+ * Assumes a single Node process.
+ */
+const SECRET = randomBytes(32);
+
+/** Humans need at least a few seconds to type a message; bots submit instantly. */
+export const TOKEN_MIN_AGE_MS = 3_000;
+export const TOKEN_MAX_AGE_MS = 60 * 60 * 1_000;
+
+const SIGNATURE_HEX_LENGTH = 64; // HMAC-SHA256
+
+export type TokenVerification =
+  | { valid: true }
+  | { valid: false; reason: 'malformed' | 'bad-signature' | 'too-young' | 'too-old' };
+
+function sign(timestamp: string): Buffer {
+  return createHmac('sha256', SECRET).update(timestamp).digest();
+}
+
+export function issueToken(now: number = Date.now()): string {
+  return `${now}.${sign(String(now)).toString('hex')}`;
+}
+
+export function verifyToken(token: string, now: number = Date.now()): TokenVerification {
+  const separator = token.indexOf('.');
+  if (separator === -1) return { valid: false, reason: 'malformed' };
+
+  const timestampPart = token.slice(0, separator);
+  const signaturePart = token.slice(separator + 1);
+
+  if (!/^\d+$/.test(timestampPart) || signaturePart.length !== SIGNATURE_HEX_LENGTH || !/^[0-9a-f]+$/.test(signaturePart)) {
+    return { valid: false, reason: 'malformed' };
+  }
+
+  const expected = sign(timestampPart);
+  const provided = Buffer.from(signaturePart, 'hex');
+  if (provided.length !== expected.length || !timingSafeEqual(provided, expected)) {
+    return { valid: false, reason: 'bad-signature' };
+  }
+
+  const age = now - Number(timestampPart);
+  if (age < TOKEN_MIN_AGE_MS) return { valid: false, reason: 'too-young' };
+  if (age > TOKEN_MAX_AGE_MS) return { valid: false, reason: 'too-old' };
+
+  return { valid: true };
+}

--- a/src/utils/email-validation.test.ts
+++ b/src/utils/email-validation.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockResolveMx } = vi.hoisted(() => ({ mockResolveMx: vi.fn() }));
+
+vi.mock('node:dns/promises', () => ({
+  resolveMx: mockResolveMx,
+}));
+
+import { isPlausibleEmail, domainAcceptsMail } from './email-validation';
+
+function dnsError(code: string): Error & { code: string } {
+  return Object.assign(new Error(code), { code });
+}
+
+describe('isPlausibleEmail', () => {
+  it.each([
+    'jane@example.com',
+    'jane.doe+tag@example.co.uk',
+    'u.lu.wafa.ju97@gmail.com',
+    'name_with-chars@sub.domain.dev',
+  ])('accepts %s', (email) => {
+    expect(isPlausibleEmail(email)).toBe(true);
+  });
+
+  it.each([
+    ['missing @', 'janeexample.com'],
+    ['two @', 'jane@doe@example.com'],
+    ['missing TLD (typo like gmailcom)', 'jane@gmailcom'],
+    ['empty local part', '@example.com'],
+    ['empty domain', 'jane@'],
+    ['space inside', 'jane doe@example.com'],
+    ['empty domain label', 'jane@example..com'],
+    ['trailing dot in domain', 'jane@example.com.'],
+    ['label starting with hyphen', 'jane@-example.com'],
+    ['single-char TLD', 'jane@example.c'],
+    ['empty string', ''],
+  ])('rejects %s: %s', (_label, email) => {
+    expect(isPlausibleEmail(email)).toBe(false);
+  });
+
+  it('rejects addresses longer than 254 characters', () => {
+    const email = `${'a'.repeat(250)}@example.com`;
+    expect(isPlausibleEmail(email)).toBe(false);
+  });
+});
+
+describe('domainAcceptsMail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('accepts when the domain has MX records', async () => {
+    mockResolveMx.mockResolvedValue([{ exchange: 'mx.example.com', priority: 10 }]);
+
+    await expect(domainAcceptsMail('jane@example.com')).resolves.toBe(true);
+    expect(mockResolveMx).toHaveBeenCalledWith('example.com');
+  });
+
+  it('rejects when the domain does not exist (typo like gmali.com)', async () => {
+    mockResolveMx.mockRejectedValue(dnsError('ENOTFOUND'));
+
+    await expect(domainAcceptsMail('jane@gmali.com')).resolves.toBe(false);
+  });
+
+  it('rejects when the domain exists but has no MX records', async () => {
+    mockResolveMx.mockRejectedValue(dnsError('ENODATA'));
+
+    await expect(domainAcceptsMail('jane@no-mail.example')).resolves.toBe(false);
+  });
+
+  it('rejects when the resolver returns an empty MX list', async () => {
+    mockResolveMx.mockResolvedValue([]);
+
+    await expect(domainAcceptsMail('jane@no-mail.example')).resolves.toBe(false);
+  });
+
+  it('fails open on other DNS failures (never lose a Lead to DNS trouble)', async () => {
+    mockResolveMx.mockRejectedValue(dnsError('SERVFAIL'));
+
+    await expect(domainAcceptsMail('jane@example.com')).resolves.toBe(true);
+  });
+
+  it('fails open when DNS is slower than the timeout', async () => {
+    mockResolveMx.mockImplementation(() => new Promise(() => {}));
+
+    await expect(domainAcceptsMail('jane@example.com', 50)).resolves.toBe(true);
+  });
+});

--- a/src/utils/email-validation.ts
+++ b/src/utils/email-validation.ts
@@ -43,9 +43,10 @@ export async function domainAcceptsMail(email: string, timeoutMs = 2_000): Promi
   const domain = email.slice(email.lastIndexOf('@') + 1);
 
   const DNS_UNCERTAIN = Symbol('dns-uncertain');
-  const timeout = new Promise<typeof DNS_UNCERTAIN>((resolve) =>
-    setTimeout(() => resolve(DNS_UNCERTAIN), timeoutMs)
-  );
+  let timerId!: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<typeof DNS_UNCERTAIN>((resolve) => {
+    timerId = setTimeout(() => resolve(DNS_UNCERTAIN), timeoutMs);
+  });
 
   try {
     const records = await Promise.race([resolveMx(domain), timeout]);
@@ -54,5 +55,7 @@ export async function domainAcceptsMail(email: string, timeoutMs = 2_000): Promi
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     return code !== 'ENOTFOUND' && code !== 'ENODATA';
+  } finally {
+    clearTimeout(timerId);
   }
 }

--- a/src/utils/email-validation.ts
+++ b/src/utils/email-validation.ts
@@ -1,0 +1,58 @@
+import { resolveMx } from 'node:dns/promises';
+
+/**
+ * Email checks exist to catch Human Mistakes (typos), not bots — a bot can
+ * trivially supply a deliverable address. Callers must treat DNS uncertainty
+ * as acceptance (fail open): rejecting a possibly-real Lead is worse than
+ * admitting Noise. See docs/adr/0001-stateless-fail-open-contact-form-defenses.md.
+ */
+
+const MAX_EMAIL_TOTAL_LENGTH = 254;
+const DOMAIN_LABEL = /^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+
+/**
+ * Pragmatic syntax check for local@domain.tld — intentionally stricter than
+ * RFC 5322 (no quoted locals, no IP domains): those never come from humans
+ * typing their own address, while `name@gmailcom` does.
+ */
+export function isPlausibleEmail(email: string): boolean {
+  if (!email || email.length > MAX_EMAIL_TOTAL_LENGTH) return false;
+
+  const atIndex = email.lastIndexOf('@');
+  if (atIndex === -1 || email.indexOf('@') !== atIndex) return false;
+
+  const local = email.slice(0, atIndex);
+  const domain = email.slice(atIndex + 1);
+
+  if (!local || /\s/.test(local)) return false;
+
+  const labels = domain.split('.');
+  if (labels.length < 2) return false;
+  if (!labels.every((label) => DOMAIN_LABEL.test(label))) return false;
+
+  const tld = labels[labels.length - 1];
+  return tld.length >= 2;
+}
+
+/**
+ * True when the email's domain publishes MX records. Definitive negatives
+ * (domain missing, no MX) reject; anything uncertain — resolver errors,
+ * slow DNS — accepts.
+ */
+export async function domainAcceptsMail(email: string, timeoutMs = 2_000): Promise<boolean> {
+  const domain = email.slice(email.lastIndexOf('@') + 1);
+
+  const DNS_UNCERTAIN = Symbol('dns-uncertain');
+  const timeout = new Promise<typeof DNS_UNCERTAIN>((resolve) =>
+    setTimeout(() => resolve(DNS_UNCERTAIN), timeoutMs)
+  );
+
+  try {
+    const records = await Promise.race([resolveMx(domain), timeout]);
+    if (records === DNS_UNCERTAIN) return true;
+    return records.length > 0;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code !== 'ENOTFOUND' && code !== 'ENODATA';
+  }
+}

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -4,6 +4,8 @@
   "testRunner": "vitest",
   "vitest": { "configFile": "vitest.config.ts" },
   "coverageAnalysis": "perTest",
+  "_ignore_comment": "Agent tooling contains directory symlinks (.claude/skills/*) that break the sandbox copy with EISDIR.",
+  "ignorePatterns": [".claude", ".agents"],
   "mutate": ["src/utils/**/*.ts", "!src/utils/**/*.test.ts"],
   "reporters": ["html", "clear-text", "progress"],
   "clearTextReporter": { "allowColor": false },


### PR DESCRIPTION
## Why

A bot slipped a gibberish submission past the contact form (nginx rate limiting kept it to *one* email — but one is enough). In the spirit of this site, the defenses are entirely DIY: no third-party captcha, no external services.

Guiding principle (recorded in [ADR 0001](docs/adr/0001-stateless-fail-open-contact-form-defenses.md)): **never lose a Lead to fight Noise.** Every defense is invisible to humans and fails open when uncertain.

## What

All enforcement lives in `POST /api/contact` — the observed bot may never have rendered the HTML:

- **Honeypot as API contract**: the `website` field must be *present and empty*. Direct API scripts (field missing) and form-fillers (field filled) both fail.
- **Form Token**: HMAC-SHA256-signed timestamp from the new `GET /api/contact-token`, verified with a minimum age of 3s (humans type, bots don't wait) and a maximum of 1h. Stateless and replayable within the window — nginx caps the blast radius. The signing secret is ephemeral (per process start); the form heals a post-deploy stale token by refetching and retrying once, invisibly.
- **Email plausibility for Human Mistakes** (not bots): syntax check + MX lookup via `node:dns`, 2s timeout, fails open on DNS uncertainty. Specific bilingual (EN/IT) error messages, while bot tripwires get one deliberately generic 400.
- **nginx**: `/api/contact-token` rate-limited from the existing CONTACT zone.
- New docs: `CONTEXT.md` glossary (Lead, Noise, Form Token, Honeypot, Tripwire Rejection, Human Mistake) + first ADR.

## Tests

- 361 tests green; new coverage: token issue/verify (12), email validation incl. fail-open paths (22), API tripwires + email codes, client token recovery flow (MSW).
- New property-based invariant: **fast-check can never forge a token, so no fuzzed payload may ever reach the mailer.**
- `astro check` clean, bundle budget within limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
